### PR TITLE
add-amanda-sarmento to contribuitors

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -8,3 +8,4 @@
 - [Gabriel Masterson Paiva Nascimento](https://github.com/gabrieldotmasterson)
 - [Fernanda Helena](https://github.com/nandahelena)
 - [Heloise Martins Barros](https://github.com/helomaster)
+- [Amanda Sarmento da Silva](https://github.com/amanda-sarmento)


### PR DESCRIPTION
Add Amanda Sarmento da Silva to Contribuitors.md, in my first open source contribuition.